### PR TITLE
Validate OpenAI API key

### DIFF
--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -13,6 +13,10 @@ import {
   titleModel,
 } from './models.test';
 
+if (!process.env.OPENAI_API_KEY) {
+  throw new Error('OPENAI_API_KEY environment variable is not set');
+}
+
 // Initialize OpenAI provider with API key from environment variables
 const openai = createOpenAI({
   apiKey: process.env.OPENAI_API_KEY,


### PR DESCRIPTION
## Summary
- check for `OPENAI_API_KEY` in the provider setup

## Testing
- `pnpm lint` *(fails: connect EHOSTUNREACH 172.24.0.3:8080)*
- `pnpm test` *(fails: connect EHOSTUNREACH 172.24.0.3:8080)*